### PR TITLE
Add mos

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -45,6 +45,7 @@ Things that produce TAP output.
 - [qunit-tap](https://github.com/twada/qunit-tap) - TAP output for QUnit.
 - [jasmine-reporters](https://github.com/larrymyers/jasmine-reporters) - TAP output for Jasmine.
 - [karma-tap-reporter](https://github.com/fumiakiy/karma-tap-reporter) - TAP output for Karma.
+- [mos](https://github.com/zkochan/mos) - A markdown file generator and tester. `$ mos test --tap`
 
 ## Fish
 


### PR DESCRIPTION
Add [mos](https://github.com/zkochan/mos) to the JavaScript section. 

A pluggable module that injects content into markdown files via hidden JavaScript snippets and tests them for being up to date and correct.

Mos can output the results of markdown testing in TAP format.
