### PR TITLE
Update tap-min URL

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@
 - [tap-dot](https://github.com/scottcorgan/tap-dot) - Dotted output.
 - [tap-spec](https://github.com/scottcorgan/tap-spec) - Mocha-like spec reporter.
 - [tap-nyan](https://github.com/calvinmetcalf/tap-nyan) - Nyan cat.
-- [tap-min](https://github.com/gummesson/tap-min) - Minimal output.
+- [tap-min](https://github.com/derhuerst/tap-min) - Minimal output.
 - [tap-difflet](https://github.com/namuol/tap-difflet) - Minimal output with diffing.
 - [tap-diff](https://github.com/axross/tap-diff) - Human-friendly output with diffing.
 - [tap-simple](https://github.com/joeybaker/tap-simple) - Simple output.


### PR DESCRIPTION
The original repository for tap-min [is no longer maintained](https://github.com/gummesson/tap-min/pull/7). The npm package is now being published from a [fork](https://github.com/derhuerst/tap-min) of the original.