### PR TITLE
Add Swift package @SwiftDocOrg/TAP to list of TAP producers

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -57,6 +57,10 @@ Things that produce TAP output.
 - [mos](https://github.com/zkochan/mos) - Markdown file generator and tester (`$ mos test --tap`).
 - [zora](https://github.com/lorenzofox3/zora) - TAP-producing test runner that works with ES2015 without Babel.
 
+### Swift
+
+- [TAP](https://github.com/swiftdocorg/tap) - A Swift package for the Test Anything Protocol (v13).
+
 ### Fish
 
 - [Fishtape](https://github.com/fisherman/fishtape) - TAP producer and test harness for fish.


### PR DESCRIPTION
For your consideration, here's [a Swift package](https://github.com/swiftdocorg/tap) I created for the TAP protocol (v13).

### Example Usage

```swift
import TAP

try TAP([
    test(1 + 1 == 2), // passes
    test(true == false) // fails
])
// Prints:
/*
TAP version 13
1..2
ok 1
not ok 2
  ---
  column: 6
  file: path/to/File.swift
  line: 5
  ...
  
*/
```